### PR TITLE
Fix: Add missing ModMenu dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ repositories {
 	// Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
 	// See https://docs.gradle.org/current/userguide/declaring_repositories.html
 	// for more information about repositories.
+	maven { url = "https://maven.terraformersmc.com/" }
 	maven { url 'https://maven.shedaniel.me/' }
 }
 
@@ -40,6 +41,7 @@ dependencies {
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 	modImplementation "me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}"
+	modImplementation "com.terraformersmc:modmenu:${project.modmenu_version}"
 	
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,4 @@ archives_base_name=modid
 # Dependencies
 fabric_version=0.129.0+1.21.8
 cloth_config_version=18.0.145
+modmenu_version=15.0.0


### PR DESCRIPTION
The build was failing during the `:compileClientJava` task because the `ModMenuIntegration` class could not find the required classes from the `com.terraformersmc.modmenu.api` package.

This was caused by a missing dependency declaration in the build scripts.

This commit fixes the issue by:
1. Adding the TerraformersMC Maven repository to `build.gradle`.
2. Adding the ModMenu dependency to `build.gradle`.
3. Defining the `modmenu_version` in `gradle.properties` to ensure a compatible version is used.